### PR TITLE
Remove xml_root_close_size as it is unused and hence redundant

### DIFF
--- a/monitor.c
+++ b/monitor.c
@@ -63,7 +63,6 @@ static const char *xml_root_open = "<records>";
 static const char *xml_root_close = "</records>";
 static const char *xml_child_open = "<record>";
 static const char *xml_child_close = "</record>";
-static const long xml_root_close_size = DIM("</records>") - 1;
 
 /**
  * Number of cores that are selected in config string


### PR DESCRIPTION
Signed-off-by: Colin Ian King <colin.king@canonical.com>