### PR TITLE
Add noreturn gcc attribute hint to parse_error

### DIFF
--- a/main.h
+++ b/main.h
@@ -109,7 +109,7 @@ strlisttotab(char *s, uint64_t *tab, const unsigned max);
  * @param arg string that caused error when parsing
  * @param note context and information about encountered error
  */
-void parse_error(const char *arg, const char *note);
+void parse_error(const char *arg, const char *note) __attribute__ ((noreturn));
 
 /**
  * @brief Duplicates \a arg and stores at \a sel


### PR DESCRIPTION
This extra hint is useful for gcc and for static analysis tools such
as scan-build - this function never returns so giving this hint is
useful to stop false positive warnings.

Signed-off-by: Colin Ian King <colin.king@canonical.com>