### PR TITLE
Fix resource leak of file pointer on error exit path

### DIFF
--- a/lib/host_monitoring.c
+++ b/lib/host_monitoring.c
@@ -952,8 +952,6 @@ pqos_core_poll(struct pqos_mon_data *p)
                 pv->mbm_total_delta = get_delta(old_value, pv->mbm_total);
                 pv->mbm_total_delta = scale_event(PQOS_MON_EVENT_TMEM_BW,
                                                   pv->mbm_total_delta);
-                if (retval != PQOS_RETVAL_OK)
-                        goto pqos_core_poll__exit;
         }
         if (p->event & PQOS_MON_EVENT_RMEM_BW) {
                 pv->mbm_remote = 0;

--- a/lib/host_pidapi.c
+++ b/lib/host_pidapi.c
@@ -858,7 +858,7 @@ static int
 set_attrs(const int idx, const char *fname)
 {
         FILE *fd;
-        int config;
+        int config, ret;
         double sf = 0;
         char file[64], buf[32], *p = buf;
 
@@ -900,12 +900,14 @@ set_attrs(const int idx, const char *fname)
                           "monitoring event scale file\n");
                 return PQOS_RETVAL_ERROR;
         }
-        if (fscanf(fd, "%lf", &sf) < 1) {
+        ret = fscanf(fd, "%lf", &sf);
+        fclose(fd);
+
+        if (ret < 1) {
                 LOG_ERROR("Failed to read PID monitoring "
                           "event scale factor!\n");
                 return PQOS_RETVAL_ERROR;
         }
-        fclose(fd);
         events_tab[idx].scale = sf;
         events_tab[idx].supported = 1;
 


### PR DESCRIPTION
Static analysis using cppcheck detected a resource leak. Fix this
by closing the file before handling the error exit path.

Signed-off-by: Colin Ian King <colin.king@canonical.com>