### PR TITLE
sort input files

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -75,7 +75,7 @@ CFLAGS += -g -O2
 endif
 
 # Build targets and dependencies
-SRCS = $(wildcard *.c)
+SRCS = $(sort $(wildcard *.c))
 OBJS = $(SRCS:.c=.o)
 CLEAN_OBJS = $(SRCS:.c=.o)
 

--- a/pqos/Makefile
+++ b/pqos/Makefile
@@ -70,7 +70,7 @@ PREFIX ?= /usr/local
 BIN_DIR = $(PREFIX)/bin
 MAN_DIR = $(PREFIX)/man/man8
 
-SRCS = $(wildcard *.c)
+SRCS = $(sort $(wildcard *.c))
 OBJS = $(SRCS:.c=.o)
 DEPFILES = $(SRCS:.c=.d)
 

--- a/rdtset/Makefile
+++ b/rdtset/Makefile
@@ -76,7 +76,7 @@ PREFIX ?= /usr/local
 BIN_DIR = $(PREFIX)/bin
 MAN_DIR = $(PREFIX)/man/man8
 
-SRCS = $(wildcard *.c)
+SRCS = $(sort $(wildcard *.c))
 OBJS = $(SRCS:.c=.o)
 DEPFILES = $(SRCS:.c=.d)
 


### PR DESCRIPTION
when building packages (e.g. for openSUSE Linux)
(random) filesystem order of input files
influences ordering of functions in the output,
thus without the patch, builds (in disposable VMs) would usually differ.

See https://reproducible-builds.org/ for why this matters.