### PR TITLE
Create relative manpage symlinks

### DIFF
--- a/pqos/Makefile
+++ b/pqos/Makefile
@@ -94,14 +94,14 @@ ifeq ($(shell uname), FreeBSD)
 	install -s $(APP) $(BIN_DIR)
 	install $(APP)-msr $(BIN_DIR)
 	install -m 0444 $(MAN) $(MAN_DIR)
-	ln -f -s $(MAN_DIR)/$(MAN) $(MAN_DIR)/$(APP)-msr.8
+	ln -f -s $(MAN) $(MAN_DIR)/$(APP)-msr.8
 else
 	install -D -s $(APP) $(BIN_DIR)/$(APP)
 	install -D $(APP)-msr $(BIN_DIR)/$(APP)-msr
 	install -D $(APP)-os $(BIN_DIR)/$(APP)-os
 	install -m 0444 $(MAN) -D $(MAN_DIR)/$(MAN)
-	ln -f -s $(MAN_DIR)/$(MAN) $(MAN_DIR)/$(APP)-msr.8
-	ln -f -s $(MAN_DIR)/$(MAN) $(MAN_DIR)/$(APP)-os.8
+	ln -f -s $(MAN) $(MAN_DIR)/$(APP)-msr.8
+	ln -f -s $(MAN) $(MAN_DIR)/$(APP)-os.8
 endif
 
 uninstall:


### PR DESCRIPTION
to fix package build with build-root.

When building packages on openSUSE Linux without this patch,
rpm post build checks failed with
error: Symlink points to BuildRoot:
/usr/share/man/man8/pqos-msr.8.gz -> /home/abuild/rpmbuild/BUILDROOT/intel-cmt-cat-1.0.1-0.0.x86_64/usr/share/man/man8/pqos.8.gz